### PR TITLE
refactor(Icon): use of Icon component everywhere

### DIFF
--- a/src/components/molecules/Button.jsx
+++ b/src/components/molecules/Button.jsx
@@ -1,4 +1,4 @@
-import { IconContext } from "react-icons";
+import { Icon } from "/src/components/molecules/Icon.jsx";
 
 export const Button = ({
   icon,
@@ -16,9 +16,7 @@ export const Button = ({
     <button
       className={`${color} ${position} ${sizeSM_w} ${sizeSM_h} ${sizeMD_w} ${sizeMD_h} flex flex-row items-center border-0 p-1 hover:rounded-lg hover:bg-primary-200`}
     >
-      <IconContext.Provider value={{ color: iconColor, size: iconSize }}>
-        {icon}
-      </IconContext.Provider>
+      <Icon iconComponent={icon} color={iconColor} size={iconSize} />
       <p className="ml-4 hidden w-3/5 text-left text-xl text-white underline md:block">
         {text}
       </p>

--- a/src/components/organisms/Sidebar.jsx
+++ b/src/components/organisms/Sidebar.jsx
@@ -22,7 +22,7 @@ export const Sidebar = ({ log }) => {
             text={data[1]}
             color="bg-primary-500"
             position={"justify-around"}
-            iconColor={"white"}
+            iconColor={"text-white"}
             iconSize={"1.25em"}
             sizeSM_w={"w-10"}
             sizeSM_h={"h-10"}


### PR DESCRIPTION
### Context
All basic components should be used widely, and the Icon component was not being used since it was recently created

### What did I do?
I made the Button component use the Icon component

#### Extras
Ideally Gifs for the feature or images in case it's needed