### PR TITLE
feat(home): create daily classes component

### DIFF
--- a/src/components/organisms/DailySchedule.jsx
+++ b/src/components/organisms/DailySchedule.jsx
@@ -1,0 +1,32 @@
+export const DailySchedule = () => {
+  const dailyClasses = [
+    { hour: "09:00 to 10:00", semester: "1", subject: "Mathematics" },
+    { hour: "10:00 to 11:00", semester: "1", subject: "Language" },
+  ];
+
+  return (
+    <div className="w-[317px] rounded-3xl bg-neutral-100 p-9 shadow-xl">
+      <h1>Daily Schedule</h1>
+      <div className="flex items-center justify-between text-neutral-400">
+        <p>
+          {new Date().getDate()} of{" "}
+          {new Date().toLocaleString("default", { month: "long" })}
+        </p>
+        <p>...</p>
+      </div>
+
+      <div className="mt-2 flex flex-col gap-4">
+        {dailyClasses.length > 0 &&
+          dailyClasses.map((element) => (
+            <div className="grid grid-cols-2 gap-4 divide-x-2 divide-black">
+              <p className="flex items-center">{element.hour}</p>
+              <div className="flex  flex-col items-start pl-3">
+                <p className="text-neutral-400">semester {element.semester}</p>
+                <p>{element.subject}</p>
+              </div>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
### Context
In the home page we need a daily classes component for the teacher

### What did I do?
- I did a component that takes an array of objects and iterates over them so it can create daily classes dinamically
- It also uses the Date object to get the day of the month and the Month in words

#### Extras
![dailyClasses](https://github.com/javonunezz/teacher_book_front/assets/62600949/5571445f-6601-4938-828e-bae3c5857de7)
