### PR TITLE
feat(student-details): create student grades

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import {
   School,
   Courses,
   CourseSubject,
+  StudentGrades,
 } from "/src/indexMain";
 
 function App() {
@@ -25,6 +26,12 @@ function App() {
         <Routes>
           <Route path="*" element={<MainContent page={<Home />} />} />
           <Route path="/home" element={<MainContent page={<Home />} />} />
+          <Route
+            path="/courses/students/student"
+            element={
+              <MainContent page={<StudentGrades showCardShadow={true} />} />
+            }
+          />
           <Route
             path="/school"
             element={<MainContent page={<School showCardShadow={true} />} />}

--- a/src/components/organisms/pages/page_courses/CourseSubject.jsx
+++ b/src/components/organisms/pages/page_courses/CourseSubject.jsx
@@ -52,7 +52,11 @@ export const CourseSubject = ({ showCardShadow }) => {
                   alt="teacher_image"
                 />
                 <h2 className="text-xl font-bold">{student.name}</h2>
-                <Link key={index} to={"/"}>
+                <Link
+                  key={index}
+                  to={"/courses/students/student"}
+                  state={{ student: student, course: course }}
+                >
                   <button className="flex h-10 w-[140px] items-center justify-center gap-6 rounded-lg bg-primary-500 text-lg text-white hover:brightness-125">
                     See details
                   </button>

--- a/src/components/organisms/pages/page_courses/StudentGrades.jsx
+++ b/src/components/organisms/pages/page_courses/StudentGrades.jsx
@@ -1,0 +1,105 @@
+import {
+  image,
+  coursesStudents,
+  useLocation,
+  BsArrowLeftShort,
+  Link,
+  Icon,
+} from "/src/components/organisms/pages/indexPages";
+import React, { useState } from "react";
+
+export const StudentGrades = ({ showCardShadow }) => {
+  const [tableType, setTableType] = useState("grades");
+  const { state } = useLocation();
+  const student = state.student;
+  const course = state.course;
+
+  const shadowClasses = showCardShadow
+    ? "lg:shadow-lg lg:rounded-3xl lg:overflow-hidden"
+    : "";
+
+  return (
+    <>
+      <div className="flex h-auto w-full justify-start pt-10">
+        <Link to={"/courses/students"} state={{ courses: course }}>
+          <button className="ml-10 flex h-[40px] w-[41px] items-center justify-center rounded-xl bg-primary-500 font-bold text-white lg:ml-20 lg:mt-20">
+            <Icon
+              iconComponent={<BsArrowLeftShort />}
+              color={"text-white"}
+              size={"30px"}
+            />
+          </button>
+        </Link>
+      </div>
+      <div
+        className={`flex w-[310px] flex-col items-center lg:mx-16 lg:h-[770px] lg:w-full ${shadowClasses}`}
+      >
+        <div className="flex w-[100vw] flex-col items-start gap-3 bg-neutral-100 p-5 lg:w-full lg:flex-row lg:items-center lg:justify-between lg:px-12 lg:py-10">
+          <div className="lg:flex lg:gap-8">
+            <div>
+              <h1 className="text-2xl font-bold">{student.name}</h1>
+              <div className="text-lg text-neutral-400">
+                <p>Gender: {student.gender}</p>
+                <p>Rut: {student.rut}</p>
+                <p>Born date: {student.bornDate}</p>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-col items-start gap-3 lg:items-end">
+            <button
+              className="rounded-xl bg-primary-200 px-6 py-3 text-lg text-white"
+              onClick={() => setTableType("grades")}
+            >
+              Grades
+            </button>
+            <button
+              className="rounded-xl bg-primary-500 px-6 py-3 text-lg text-white"
+              onClick={() => setTableType("observations")}
+            >
+              Observations
+            </button>
+          </div>
+        </div>
+
+        {tableType === "grades" && <Table student={student} type="grades" />}
+        {tableType === "observations" && (
+          <Table student={student} type="observations" />
+        )}
+      </div>
+    </>
+  );
+};
+
+const Table = ({ student, type }) => {
+  return (
+    <div className="flex h-full w-full items-center justify-center  lg:px-36">
+      <div className="my-4 grid w-[330px] grid-cols-2  overflow-hidden rounded-3xl shadow-lg lg:max-h-[380px]  lg:w-full lg:overflow-y-scroll lg:scrollbar-thin lg:scrollbar-track-neutral-100 lg:scrollbar-thumb-neutral-200">
+        <div className="flex h-[80px] items-center justify-center bg-primary-500 text-xl font-bold text-white">
+          {type === "grades" ? "Test names" : "Type"}
+        </div>
+        <div className="flex h-[80px] items-center justify-center bg-primary-500 text-xl font-bold text-white">
+          {type === "grades" ? "Grade" : "Observation"}
+        </div>
+
+        {student[type].map((obj, index) => (
+          <React.Fragment key={index}>
+            <div
+              className={`flex items-center justify-center p-4 ${
+                index % 2 === 0 ? "bg-gray-200" : "bg-white"
+              }`}
+            >
+              {type === "grades" ? obj.name : obj.type}
+            </div>
+            <div
+              className={`flex items-center justify-center p-4 ${
+                index % 2 === 0 ? "bg-gray-200" : "bg-white"
+              }`}
+            >
+              {type === "grades" ? obj.grade : obj.observation}
+            </div>
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/organisms/pages/page_courses/coursesStudents.json
+++ b/src/components/organisms/pages/page_courses/coursesStudents.json
@@ -4,27 +4,105 @@
     "students": [
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "1",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 },
+          { "name": "test 4", "grade": 4.0 },
+          { "name": "test 5", "grade": 7.0 },
+          { "name": "test 6", "grade": 3.9 },
+          { "name": "test 7", "grade": 5.3 },
+          { "name": "test 8", "grade": 5.3 },
+          { "name": "test 9", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "2",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "3",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "4",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "5",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "6",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       }
     ]
   },
@@ -33,27 +111,99 @@
     "students": [
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "7",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "8",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "9",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "10",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "11",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "12",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       }
     ]
   },
@@ -62,27 +212,99 @@
     "students": [
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "13",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "14",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "15",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "16",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "17",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "18",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       }
     ]
   },
@@ -91,27 +313,99 @@
     "students": [
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "19",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "20",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "21",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "22",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "23",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "24",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       }
     ]
   },
@@ -120,27 +414,99 @@
     "students": [
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "25",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "26",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "27",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "28",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "29",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "30",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       }
     ]
   },
@@ -149,27 +515,99 @@
     "students": [
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "31",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "32",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Juan Perez",
-        "gender": "Boy"
+        "rut": "33",
+        "gender": "Boy",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "34",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "35",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       },
       {
         "name": "Pamela Chu",
-        "gender": "Girl"
+        "rut": "36",
+        "gender": "Girl",
+        "bornDate": "11/11/2004",
+        "grades": [
+          { "name": "test 1", "grade": 5.0 },
+          { "name": "test 2", "grade": 5.5 },
+          { "name": "test 3", "grade": 6.0 }
+        ],
+        "observations": [
+          { "type": "good", "observation": "The kid finally walks on class" },
+          { "type": "bad", "observation": "The kid went running in the class" },
+          { "type": "good", "observation": "The kid ate his whole meal" }
+        ]
       }
     ]
   }

--- a/src/indexMain.js
+++ b/src/indexMain.js
@@ -7,6 +7,7 @@ import { Settings } from "/src/components/organisms/pages/page_settings/Settings
 import { School } from "./components/organisms/pages/page_school/School";
 import { Courses } from "/src/components/organisms/pages/page_courses/Courses";
 import { CourseSubject } from "./components/organisms/pages/page_courses/CourseSubject";
+import { StudentGrades } from "./components/organisms/pages/page_courses/StudentGrades";
 
 export {
   Routes,
@@ -20,4 +21,5 @@ export {
   School,
   Courses,
   CourseSubject,
+  StudentGrades,
 };


### PR DESCRIPTION
### Context
We need to create a profile for a specific student, that shows it's grades and observations and let you return to the courses.

### What did I do?
- I created a responsive component that shows the student details
- It needs a small fix on the mobile design where the background of the profile doesn't get to the top of the viewport because of the MainContent component top padding


#### Extras
![studentGrades](https://github.com/javonunezz/teacher_book_front/assets/62600949/e03e587e-c459-4347-9d9b-c3bb04eeeeab)
